### PR TITLE
[Scanner] `TokenType` no associated value and `Literal` with optional…

### DIFF
--- a/Sources/ilox/AST/.sourcery.yml
+++ b/Sources/ilox/AST/.sourcery.yml
@@ -15,7 +15,7 @@ args:
       "Expr": "expression"
     ],
     "Literal": [
-      "AnyObject": "value"
+      "AnyObject?": "value"
     ],
     "Unary": [
       "Token": "op",

--- a/Sources/ilox/AST/Printer.swift
+++ b/Sources/ilox/AST/Printer.swift
@@ -21,10 +21,10 @@ class ASTPrinter : Visitor {
     }
 
     func visitExprLiteral(expr: Literal) -> String {
-        if (expr.value == nil) {
-            return "nil"
+        if let val = expr.value {
+            return "\(val)"
         }
-        return "\(expr.value)"
+        return "nil"
     }
 
     func visitExprUnary(expr: Unary) -> String {

--- a/Sources/ilox/AST/PrinterRPN.swift
+++ b/Sources/ilox/AST/PrinterRPN.swift
@@ -21,10 +21,10 @@ class ASTPrinterRPN : Visitor {
     }
 
     func visitExprLiteral(expr: Literal) -> String {
-        if (expr.value == nil) {
-            return "nil"
+        if let val = expr.value {
+            return "\(val)"
         }
-        return "\(expr.value)"
+        return "nil"
     }
 
     func visitExprUnary(expr: Unary) -> String {

--- a/Sources/ilox/Scanner.swift
+++ b/Sources/ilox/Scanner.swift
@@ -116,7 +116,7 @@ class Scanner {
         advance()
         
         let value = source[(start + 1)...(current - 2)]
-        addTokenOf(type: .STRING(String(value)))
+        addTokenOf(type: .STRING, with: value as AnyObject)
     }
         
     private func consumeNumber() {
@@ -129,7 +129,8 @@ class Scanner {
         while(Scanner.isDigit(peek())) {
             advance()
         }
-        addTokenOf(type: .NUMBER(Double(String(source[start...current]))!))
+        addTokenOf(type: .NUMBER,
+                   with: Double(String(source[start...current]))! as AnyObject)
     }
     
     private func consumeIdentifier() {
@@ -140,7 +141,7 @@ class Scanner {
         if let keywordType = Scanner.keywords[text] {
             addTokenOf(type: keywordType)
         } else {
-            addTokenOf(type: .IDENTIFIER(text))
+            addTokenOf(type: .IDENTIFIER)
         }
     }
     

--- a/Sources/ilox/Token.swift
+++ b/Sources/ilox/Token.swift
@@ -15,7 +15,7 @@ enum TokenType: Comparable {
     case BANG, BANG_EQUAL, EQUAL, EQUAL_EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL
     
     // Literals
-    case IDENTIFIER(String), STRING(String), NUMBER(Double)
+    case IDENTIFIER, STRING, NUMBER
     
     // Keywords
     case AND, CLASS, ELSE, FALSE, FUN, FOR, IF, NIL, OR, PRINT, RETURN, SUPER, THIS, TRUE, VAR, WHILE, EOF

--- a/Tests/iloxTests/scannerTests.swift
+++ b/Tests/iloxTests/scannerTests.swift
@@ -37,7 +37,7 @@ final class scannerTests: XCTestCase {
 
     func testScanningStrings() throws {
         XCTAssert(fileCheckOutput(withPrefixes: ["STR_TOKENS"], options: .disableColors) {
-            // STR_TOKENS: STRING("Ta Tb") "Ta Tb" nil
+            // STR_TOKENS: STRING "Ta Tb" Optional(Ta Tb)
             // STR_TOKENS-NEXT: EOF  nil
             loxInterpreter.run(code: "\"Ta Tb\"")
         })
@@ -45,7 +45,7 @@ final class scannerTests: XCTestCase {
 
     func testScanningNumbers() throws {
         XCTAssert(fileCheckOutput(withPrefixes: ["NUM_TOKENS"], options: .disableColors) {
-            // NUM_TOKENS: NUMBER(3.14) 3.14 nil
+            // NUM_TOKENS: NUMBER 3.14 Optional(3.14)
             // NUM_TOKENS-NEXT: EOF  nil
             loxInterpreter.run(code: "3.14")
         })
@@ -63,7 +63,7 @@ final class scannerTests: XCTestCase {
     
     func testScanningIdentifiers() throws {
         XCTAssert(fileCheckOutput(withPrefixes: ["IDENTIFIER_TOKENS"], options: .disableColors) {
-            // IDENTIFIER_TOKENS: IDENTIFIER("thisIsAnIdentifier") thisIsAnIdentifier nil
+            // IDENTIFIER_TOKENS: IDENTIFIER thisIsAnIdentifier nil
             // IDENTIFIER_TOKENS-NEXT: EOF  nil
             loxInterpreter.run(code: "thisIsAnIdentifier")
         })


### PR DESCRIPTION
… value.

This introduces two changes in how tokens are handled.

1. `TokenType` has no more associated values: Literals, Strings and Number
tokens had associated values but that does not allow for comparing
two Tokens based on the token type without taking into account the
associated value, i.e. it was not possible to compare if two given tokens
were Strings without looking at the associated literal string.
This is specially key when writting parsing code.

2. In Lox, we can use `nil`. During scanning, it is represented by
a `Literal` token. As `Literal` can represent a String and a Number,
the value has type `AnyObject`. Unfortunately in swift, `nil` can't be
casted to `AnyObject`, hence the value attached to a literal is from
now on, `Optional(AnyObject)`.