### PR TITLE
Renaming `Error` utility enum to `ErrorUtil`.

### DIFF
--- a/Sources/ilox/ErrorUtil.swift
+++ b/Sources/ilox/ErrorUtil.swift
@@ -7,9 +7,17 @@
 
 import Foundation
 
-enum Error {
-    static func error(line: Int, message:String) {
+enum ErrorUtil {
+    static func error(line: Int, message: String) {
         report(line: line, within: "", message: message)
+    }
+
+    static func error(token: Token, message: String) {
+        if (token.type == TokenType.EOF) {
+            report(line: token.line, within: " at end", message: message)
+        } else {
+            report(line: token.line, within: "at '\(token.lexeme)'", message: message)
+        }
     }
 
     static func report(line: Int, within location: String, message: String) {

--- a/Sources/ilox/Scanner.swift
+++ b/Sources/ilox/Scanner.swift
@@ -110,7 +110,7 @@ class Scanner {
         }
         
         if (isAtEnd) {
-            Error.error(line: line, message: "Unterminated string.")
+            ErrorUtil.error(line: line, message: "Unterminated string.")
             return
         }
         advance()
@@ -189,7 +189,7 @@ class Scanner {
                     advance()
                 }
                 if (nestedComments != 0) {
-                    Error.error(line: line, message: "Unterminated comment(*/)")
+                    ErrorUtil.error(line: line, message: "Unterminated comment(*/)")
                     break;
                 }
             } else {
@@ -215,7 +215,7 @@ class Scanner {
             } else if (Scanner.isAlpha(c)) {
                 consumeIdentifier()
             } else {
-                Error.error(line: line, message: "Unrecognized character: '\(c)'")
+                ErrorUtil.error(line: line, message: "Unrecognized character: '\(c)'")
                 break;
             }
         }


### PR DESCRIPTION
To avoid name class with `Error` protocol.