### PR TITLE
[eval] Allowing + operator concatenate String and Doubles.

### DIFF
--- a/Sources/ilox/Interpreter.swift
+++ b/Sources/ilox/Interpreter.swift
@@ -75,9 +75,12 @@ class Interpreter : Visitor {
                 if let unwrappedLeft = left, let unwrappedRight = right {
                     if unwrappedLeft is Double && unwrappedRight is Double {
                         return (unwrappedLeft as! Double) + (unwrappedRight as! Double) as AnyObject
-                    }
-                    if unwrappedLeft is String && unwrappedRight is String {
+                    } else if unwrappedLeft is String && unwrappedRight is String {
                         return (unwrappedLeft as! String) + (unwrappedRight as! String) as AnyObject
+                    } else if unwrappedLeft is String {
+                        return (unwrappedLeft as! String) + String(unwrappedRight as! Double) as AnyObject
+                    } else if unwrappedRight is String {
+                        return String(unwrappedLeft as! Double) + (unwrappedRight as! String) as AnyObject
                     }
 
                     try! throwPlusOperandsError(token: expr.op)

--- a/Tests/iloxTests/interpreterTests.swift
+++ b/Tests/iloxTests/interpreterTests.swift
@@ -12,7 +12,7 @@ import FileCheck
 final class interpreterTests: XCTestCase {
     let loxInterpreter = Lox()
 
-    func numericExpressions() throws {
+    func testNumericExpressions() throws {
         XCTAssert(fileCheckOutput(withPrefixes: ["NUM"], options: .disableColors) {
             // NUM: 5
             loxInterpreter.run(code: "3 + 2", with: .interpret)
@@ -25,18 +25,28 @@ final class interpreterTests: XCTestCase {
         })
     }
 
-    func stringExpressions() throws {
+    func testStringExpressions() throws {
         XCTAssert(fileCheckOutput(withPrefixes: ["STR"], options: .disableColors) {
             // STR: abcd
             loxInterpreter.run(code: "\"ab\" + \"cd\"", with: .interpret)
         })
     }
 
+    func testAddStringAndNumbers() throws {
+        XCTAssert(fileCheckOutput(withPrefixes: ["STR_NUM"], options: .disableColors) {
+            // STR_NUM: 23.3ab
+            loxInterpreter.run(code: "23.3 + \"ab\"", with: .interpret)
+            // STR_NUM: ab23.3
+            loxInterpreter.run(code: "\"ab\" + 23.3", with: .interpret)
+        })
+    }
+
 
 #if !os(macOS)
     static var allTests = testCase([
-        ("numericExpressions", numericExpressions),
-        ("stringExpressions", stringExpressions)
+        ("testNumericExpressions", numericExpressions),
+        ("testStringExpressions", stringExpressions),
+        ("testAddStringAndNumbers", addStringAndNumbers)
     ])
 #endif
 }


### PR DESCRIPTION
If either of both operands is a `String` we convert the numeric
value to `String` as well and do concatenation as a resulting
operation.