### PR TITLE
Refactoring error handling in the stack.

### DIFF
--- a/Sources/ilox/AST/Templates/ASyntaxTree.stencil
+++ b/Sources/ilox/AST/Templates/ASyntaxTree.stencil
@@ -9,8 +9,21 @@ protocol Visitor {
 {% endfor %}
 }
 
+protocol ThrowableVisitor {
+    associatedtype Return
+{% for typeDef in argument.types %}
+    {% for exprType, _ in typeDef %}
+    func visit{{argument.baseName}}{{exprType}}({{argument.baseName|lowercase}}:{{exprType}}) throws -> Return
+    {% endfor %}
+{% endfor %}
+}
+
+
 class {{argument.baseName}} {
     func accept<V: Visitor>(visitor: V) -> V.Return {
+        fatalError("You are not allowed to call `accept` from `Expr` class")
+    }
+    func accept<V: ThrowableVisitor>(visitor: V) throws -> V.Return {
         fatalError("You are not allowed to call `accept` from `Expr` class")
     }
 }
@@ -38,6 +51,9 @@ class {{exprType}} : {{argument.baseName}} {
 
     override func accept<V: Visitor>(visitor: V) -> V.Return {
         return visitor.visit{{argument.baseName}}{{exprType}}(expr: self)
+    }
+    override func accept<V: ThrowableVisitor>(visitor: V) throws -> V.Return {
+        return try visitor.visit{{argument.baseName}}{{exprType}}(expr: self)
     }
 }
     {% endfor %}

--- a/Sources/ilox/ErrorUtil.swift
+++ b/Sources/ilox/ErrorUtil.swift
@@ -7,6 +7,36 @@
 
 import Foundation
 
+enum LoxError : Error {
+    case parse
+
+    enum Runtime : Error {
+        case operandNotNumber(token: Token)
+        case operandsNotNumbers(token: Token)
+        case operandsNotNumbersNorStrings(token: Token)
+        case divisionByZero(token: Token)
+    }
+
+    case runtime(ofKind: Runtime)
+}
+
+extension LoxError.Runtime : LocalizedError {
+    var errorDescription: String? {
+        switch self {
+            case .operandNotNumber(token: _):
+                return "Operand must be a number."
+            case .operandsNotNumbers(token: _):
+                return "Operands must be numbers."
+            case .operandsNotNumbersNorStrings(token: _):
+                return "Operands must be either Numbers or Strings"
+            case .divisionByZero(token: let tok):
+                return "Division by zero at line: \(tok.line) "
+        }
+    }
+}
+
+
+
 enum ErrorUtil {
     static func error(line: Int, message: String) {
         report(line: line, within: "", message: message)
@@ -24,7 +54,10 @@ enum ErrorUtil {
         FileHandle.standardError.write("[line \(line)] Error \(location): \(message)\n".data(using: .utf8)!)
     }
 
-    static func runtimeError(rerror: Interpreter.RuntimeError) {
-        FileHandle.standardError.write((rerror.errorDescription?.data(using: .utf8))!)
+    static func runtimeError(rerror: LoxError) {
+        if case LoxError.runtime(let kind) = rerror {
+            let errorMsg = ("\(String(describing: kind.errorDescription!))\n".data(using: .utf8))!
+            FileHandle.standardError.write(errorMsg)
+        }
     }
 }

--- a/Sources/ilox/Parse/Parser.swift
+++ b/Sources/ilox/Parse/Parser.swift
@@ -5,10 +5,6 @@
 //  Created by Victor Guerra on 07/10/2021.
 //
 
-enum ParseError: Error {
-    case parse
-}
-
 final class Parser {
     let tokens: [Token]
     var current: Int = 0
@@ -66,7 +62,7 @@ final class Parser {
     }
 
     // MARK: Parsing of grammar, each rule represented by one method
-    private func expression() throws -> Expr {
+private func expression() throws -> Expr {
         return try expressionBlock()
     }
 
@@ -213,9 +209,9 @@ final class Parser {
         throw error(peek(), message)
     }
 
-    private func error(_ token: Token, _ message: String) -> ParseError {
+    private func error(_ token: Token, _ message: String) -> LoxError {
         ErrorUtil.error(token: token, message: message)
-        return ParseError.parse
+        return LoxError.parse
     }
 
     private func synchronize() {

--- a/Tests/iloxTests/interpreterTests.swift
+++ b/Tests/iloxTests/interpreterTests.swift
@@ -41,12 +41,20 @@ final class interpreterTests: XCTestCase {
         })
     }
 
+    func testDivisionByZero() throws {
+        XCTAssert(fileCheckOutput(of: .stderr, withPrefixes: ["DIV_ZERO"], options: .disableColors) {
+            // DIV_ZERO: Division by zero at line: 1
+            loxInterpreter.run(code: "3 / 0", with: .interpret)
+        })
+    }
+
 
 #if !os(macOS)
     static var allTests = testCase([
         ("testNumericExpressions", numericExpressions),
         ("testStringExpressions", stringExpressions),
-        ("testAddStringAndNumbers", addStringAndNumbers)
+        ("testAddStringAndNumbers", addStringAndNumbers),
+        ("testDivisionByZero", testDivisionByZero)
     ])
 #endif
 }


### PR DESCRIPTION
When executing the interpretation phase of the compiler,
we needed to propagate the errors we throw up the stack
to be able to handle them properly.

In order to surface the errors we threw we needed to mark
all functions that evaluate an expression as *throwing*
(suffix `throw` added to functions) and since we are using
the Visitor pattern based on protocols, a new protocol was defined
that marks all possible visit functions marked as throwing.

As well, we centralized everything related to errors (enums
and utilities) in `ErrorUtil.swift` and there is an enum
that encapsulates all possible errors in all phases of the compiler.

This new way of handling exceptions when visiting and evaluating
the AST simply how we handle errors when executing files
and in the REPL.