### PR TITLE
[parse] Refactoring auto-generated expression classes.

### DIFF
--- a/Sources/ilox/AST/Printer.swift
+++ b/Sources/ilox/AST/Printer.swift
@@ -5,7 +5,7 @@
 //  Created by Victor Guerra on 27/09/2021.
 //
 
-class ASTPrinter : Visitor {
+class ASTPrinter : ExprVisitor {
     typealias Return = String
 
     func print(expr: Expr) -> String {

--- a/Sources/ilox/AST/PrinterRPN.swift
+++ b/Sources/ilox/AST/PrinterRPN.swift
@@ -5,7 +5,7 @@
 //  Created by Victor Guerra on 27/09/2021.
 //
 
-class ASTPrinterRPN : Visitor {
+class ASTPrinterRPN : ExprVisitor {
     typealias Return = String
 
     func visitExprExprBlock(expr: ExprBlock) -> String {

--- a/Sources/ilox/AST/Templates/AbstractSyntaxTree.stencil
+++ b/Sources/ilox/AST/Templates/AbstractSyntaxTree.stencil
@@ -1,6 +1,6 @@
 // Automated definitions for {{argument.baseName}}
 
-protocol Visitor {
+protocol {{argument.baseName}}Visitor {
     associatedtype Return
 {% for typeDef in argument.types %}
     {% for exprType, _ in typeDef %}
@@ -9,7 +9,7 @@ protocol Visitor {
 {% endfor %}
 }
 
-protocol ThrowableVisitor {
+protocol {{argument.baseName}}ThrowableVisitor {
     associatedtype Return
 {% for typeDef in argument.types %}
     {% for exprType, _ in typeDef %}
@@ -20,10 +20,10 @@ protocol ThrowableVisitor {
 
 
 class {{argument.baseName}} {
-    func accept<V: Visitor>(visitor: V) -> V.Return {
+    func accept<V: {{argument.baseName}}Visitor>(visitor: V) -> V.Return {
         fatalError("You are not allowed to call `accept` from `Expr` class")
     }
-    func accept<V: ThrowableVisitor>(visitor: V) throws -> V.Return {
+    func accept<V: {{argument.baseName}}ThrowableVisitor>(visitor: V) throws -> V.Return {
         fatalError("You are not allowed to call `accept` from `Expr` class")
     }
 }
@@ -49,10 +49,10 @@ class {{exprType}} : {{argument.baseName}} {
         {% endfor %}
     }
 
-    override func accept<V: Visitor>(visitor: V) -> V.Return {
+    override func accept<V: {{argument.baseName}}Visitor>(visitor: V) -> V.Return {
         return visitor.visit{{argument.baseName}}{{exprType}}(expr: self)
     }
-    override func accept<V: ThrowableVisitor>(visitor: V) throws -> V.Return {
+    override func accept<V: {{argument.baseName}}ThrowableVisitor>(visitor: V) throws -> V.Return {
         return try visitor.visit{{argument.baseName}}{{exprType}}(expr: self)
     }
 }

--- a/Sources/ilox/AST/expressions.sourcery.yml
+++ b/Sources/ilox/AST/expressions.sourcery.yml
@@ -2,7 +2,7 @@ sources:
   - "."
 templates:
   - "Templates"
-output: "."
+output: "./Expr.generated.swift"
 args:
   baseName: "Expr"
   types: [

--- a/Sources/ilox/Interpreter.swift
+++ b/Sources/ilox/Interpreter.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 
-class Interpreter : ThrowableVisitor {
+class Interpreter : ExprThrowableVisitor {
 
     typealias Return = AnyObject?
 


### PR DESCRIPTION
As the same template will be used to generate the needed classes
and visitor protocols to handle statements. So we need to prefix
the visitor protocols with the base class, `Expr` in the case
of expressions.