### PR TITLE
[parse] Avoiding name clash for associated types in Visitor protocols.

### DIFF
--- a/Sources/ilox/AST/Printer.swift
+++ b/Sources/ilox/AST/Printer.swift
@@ -6,7 +6,7 @@
 //
 
 class ASTPrinter : ExprVisitor {
-    typealias Return = String
+    typealias ExprRetrun = String
 
     func print(expr: Expr) -> String {
         return expr.accept(visitor: self)

--- a/Sources/ilox/AST/PrinterRPN.swift
+++ b/Sources/ilox/AST/PrinterRPN.swift
@@ -6,7 +6,7 @@
 //
 
 class ASTPrinterRPN : ExprVisitor {
-    typealias Return = String
+    typealias ExprReturn = String
 
     func visitExprExprBlock(expr: ExprBlock) -> String {
         return parenthesize(name: "expr-block", expr.head, expr.tail)

--- a/Sources/ilox/AST/Templates/AbstractSyntaxTree.stencil
+++ b/Sources/ilox/AST/Templates/AbstractSyntaxTree.stencil
@@ -1,29 +1,29 @@
 // Automated definitions for {{argument.baseName}}
 
 protocol {{argument.baseName}}Visitor {
-    associatedtype Return
+    associatedtype {{argument.baseName}}Return
 {% for typeDef in argument.types %}
     {% for exprType, _ in typeDef %}
-    func visit{{argument.baseName}}{{exprType}}({{argument.baseName|lowercase}}: {{exprType}}) -> Return
+    func visit{{argument.baseName}}{{exprType}}({{argument.baseName|lowercase}}: {{exprType}}) -> {{argument.baseName}}Return
     {% endfor %}
 {% endfor %}
 }
 
 protocol {{argument.baseName}}ThrowableVisitor {
-    associatedtype Return
+    associatedtype {{argument.baseName}}Return
 {% for typeDef in argument.types %}
     {% for exprType, _ in typeDef %}
-    func visit{{argument.baseName}}{{exprType}}({{argument.baseName|lowercase}}: {{exprType}}) throws -> Return
+    func visit{{argument.baseName}}{{exprType}}({{argument.baseName|lowercase}}: {{exprType}}) throws -> {{argument.baseName}}Return
     {% endfor %}
 {% endfor %}
 }
 
 
 class {{argument.baseName}} {
-    func accept<V: {{argument.baseName}}Visitor>(visitor: V) -> V.Return {
+    func accept<V: {{argument.baseName}}Visitor>(visitor: V) -> V.{{argument.baseName}}Return {
         fatalError("You are not allowed to call `accept` from `Expr` class")
     }
-    func accept<V: {{argument.baseName}}ThrowableVisitor>(visitor: V) throws -> V.Return {
+    func accept<V: {{argument.baseName}}ThrowableVisitor>(visitor: V) throws -> V.{{argument.baseName}}Return {
         fatalError("You are not allowed to call `accept` from `Expr` class")
     }
 }
@@ -49,10 +49,10 @@ class {{exprType}} : {{argument.baseName}} {
         {% endfor %}
     }
 
-    override func accept<V: {{argument.baseName}}Visitor>(visitor: V) -> V.Return {
+    override func accept<V: {{argument.baseName}}Visitor>(visitor: V) -> V.{{argument.baseName}}Return {
         return visitor.visit{{argument.baseName}}{{exprType}}({{argument.baseName|lowercase}}: self)
     }
-    override func accept<V: {{argument.baseName}}ThrowableVisitor>(visitor: V) throws -> V.Return {
+    override func accept<V: {{argument.baseName}}ThrowableVisitor>(visitor: V) throws -> V.{{argument.baseName}}Return {
         return try visitor.visit{{argument.baseName}}{{exprType}}({{argument.baseName|lowercase}}: self)
     }
 }

--- a/Sources/ilox/Interpreter.swift
+++ b/Sources/ilox/Interpreter.swift
@@ -13,7 +13,7 @@ import Foundation
 
 class Interpreter : ExprThrowableVisitor {
 
-    typealias Return = AnyObject?
+    typealias ExprReturn = AnyObject?
 
     func interpret(expression: Expr) throws {
         print(stringify(value: try evaluate(expr: expression)))


### PR DESCRIPTION
We recently introduced visitor protocol for statements but the
associated type that will be returned by each visit function
was left as `Return` inducing a name clash when we want to make
the `Interpreter` class to be able to navigate `Expr`s and `Stmt`s
at the same time (by conforming to both visitor protocols).

Therefore we only way to avoid the clash is to rename the associated
type.