### PR TITLE
[eval] Introducing a container to keep track of variable values.

### DIFF
--- a/Sources/ilox/Environment.swift
+++ b/Sources/ilox/Environment.swift
@@ -1,0 +1,23 @@
+//
+//  Environment.swift
+//  
+//
+//  Created by Victor Guerra on 25/11/2021.
+//
+
+final class Environment {
+    var values: [String: AnyObject?] = [:]
+
+    init() {}
+
+    func get(_ name: Token) throws -> AnyObject? {
+        if let value = values[name.lexeme] {
+            return value
+        }
+        throw LoxError.runtime(ofKind: LoxError.Runtime.undefinedVariable(token: name))
+    }
+
+    func define(_ name: String, with value: AnyObject?) {
+        values.updateValue(value, forKey: name)
+    }
+}

--- a/Sources/ilox/ErrorUtil.swift
+++ b/Sources/ilox/ErrorUtil.swift
@@ -15,6 +15,7 @@ enum LoxError : Error {
         case operandsNotNumbers(token: Token)
         case operandsNotNumbersNorStrings(token: Token)
         case divisionByZero(token: Token)
+        case undefinedVariable(token: Token)
     }
 
     case runtime(ofKind: Runtime)
@@ -31,6 +32,8 @@ extension LoxError.Runtime : LocalizedError {
                 return "Operands must be either Numbers or Strings"
             case .divisionByZero(token: let tok):
                 return "Division by zero at line: \(tok.line) "
+            case .undefinedVariable(token: let tok):
+                return "Undefined variable \(tok.lexeme) at line \(tok.line)."
         }
     }
 }

--- a/Sources/ilox/Interpreter.swift
+++ b/Sources/ilox/Interpreter.swift
@@ -16,6 +16,8 @@ class Interpreter : ExprThrowableVisitor, StmtThrowableVisitor {
     typealias ExprReturn = AnyObject?
     typealias StmtReturn = Void
 
+    private let environment = Environment()
+
     func interpret(statements : [Stmt]) {
         do {
             for statement in statements {
@@ -47,11 +49,15 @@ class Interpreter : ExprThrowableVisitor, StmtThrowableVisitor {
     }
 
     func visitExprVariable(expr: Variable) throws -> AnyObject? {
-        fatalError("not implemented")
+        return try environment.get(expr.name)
     }
 
     func visitStmtVar(stmt: Var) throws -> Void {
-        fatalError("not implemented")
+        if let initializer = stmt.initializer {
+            environment.define(stmt.name.lexeme, with: try evaluate(expr: initializer))
+        } else {
+            environment.define(stmt.name.lexeme, with: nil)
+        }
     }
 
     func visitStmtExpression(stmt: Expression) throws -> Void {

--- a/Tests/iloxTests/interpreterTests.swift
+++ b/Tests/iloxTests/interpreterTests.swift
@@ -48,13 +48,26 @@ final class interpreterTests: XCTestCase {
         })
     }
 
+    func testVariables() throws {
+        XCTAssert(fileCheckOutput(withPrefixes: ["VARS"], options: .disableColors) {
+            // VARS: 3
+            loxInterpreter.run(
+                code: """
+                var a = 1;
+                var b = 2;
+                print a + b;
+            """, with: .interpret)
+        })
+    }
+
 
 #if !os(macOS)
     static var allTests = testCase([
         ("testNumericExpressions", numericExpressions),
         ("testStringExpressions", stringExpressions),
         ("testAddStringAndNumbers", addStringAndNumbers),
-        ("testDivisionByZero", testDivisionByZero)
+        ("testDivisionByZero", testDivisionByZero),
+        ("testVariables", testVariables)
     ])
 #endif
 }


### PR DESCRIPTION
`Environment` encapsulates a dictionary to keep track of
values assigned to variables. For the time being the dictionary
is populated whenever a variable is defined. If the variable
definition includes an expression then it is evaluated and the
result is put in as value. Otherwise the entry contains `nil`.

`var a = 32;` will put in the dictionary the entry `a -> 32`.
`var a;` will put in the dictionary the entry `nil`.

Variable re-definition is allowed for now and we can not change
the value of a variable.